### PR TITLE
How to use the plugin: readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Zotero Report Customizer
 
+To use Zotero Report Customizer, simply select the "Report Customizer…" option from the Zotero Actions Menu (the small gear icon: ![Zotero Actions Menu](https://www.zotero.org/support/_media/gear.png?w=16).)
+
 Install by downloading the [latest version](https://zotplus.github.io/report-customizer/zotero-report-customizer-0.2.13.xpi)) (**0.2.13**). If you are not
 prompted with a Firefox installation dialog then double-click the downloaded xpi; Firefox ought to start and present you
 with the installation dialog.

--- a/chrome/locale/en-US/zotero-report-customizer/zotero-report-customizer.dtd
+++ b/chrome/locale/en-US/zotero-report-customizer/zotero-report-customizer.dtd
@@ -1,4 +1,4 @@
-<!ENTITY zotero-report-customizer.name "Report Customizer">
+<!ENTITY zotero-report-customizer.name "Report Customizer…">
 <!ENTITY zotero-report-customizer.show "Fields to show in report">
 <!ENTITY zotero-report-customizer.sort "Report sort order">
 <!ENTITY zotero-report-customizer.field "Field">


### PR DESCRIPTION
-It took me several minutes to find how to use the plugin. And I'm not alone: https://forums.zotero.org/discussion/45907/zotero-report-customization-for-mac/?Focus=215035#Comment_215035
-Add ellipsis (…) to Menu Label: "Report Customizer…"

[and btw, I'm not able to run the extension directly from my local git installation. When I click on "Report Customizer" I get this error in the console: "Zotero.ReportCustomizer is undefined browser.xul:1:0" — any idea ? It seems to work well otherwise, i.e. with normal zotero and plugin installation]